### PR TITLE
Fix login issue caused by deletion of linked documents

### DIFF
--- a/delta-pdf-api/services/document_service.py
+++ b/delta-pdf-api/services/document_service.py
@@ -41,7 +41,10 @@ def delete_document(uuid, user):
     document = get_document_by_uuid(uuid)
     if document.user.id != user.id:
         raise UnauthorizedError("You do not have permission to delete the document.")
-    document.delete()
+    if len(document.contracts) == 0:
+        document.delete()
+    else:
+        raise BadRequest("There are Contracts that rely on this Document. You cannot delete this!")
 
 
 @db_session

--- a/mobileapp/lib/database/server_operation.dart
+++ b/mobileapp/lib/database/server_operation.dart
@@ -204,10 +204,10 @@ class ServerOp {
         await _dbDocumentOp.delete(document);
         print("done");
 
-        return true;
+        return {"deleted":true , "message":"Deleted Successfully"};
       } else {
         print("error");
-        return false;
+        return {"deleted":false, "message" : response.data["detail"].toString()};
       }
     } on DioError catch (e) {
       print(e.response.statusCode);
@@ -215,11 +215,11 @@ class ServerOp {
       print(e.response);
       if (e.response != null) {
         print("failed");
-        return false;
+        return {"deleted":false, "message" : e.response.data["detail"].toString()};
       }
     } catch (e) {
       print("caught error  $e");
-      return false;
+      return {"deleted":false, "message" : "unknown issue"};
     }
   }
 

--- a/mobileapp/lib/screens/homescreen/home_screen.dart
+++ b/mobileapp/lib/screens/homescreen/home_screen.dart
@@ -592,7 +592,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future _deleteDoc(int index) async {
     var result = await _serverOp.deleteDoc(_documents[index]);
-    if (result) {
+    if (result["deleted"]) {
       setState(() {
         _documents.removeAt(index);
         isLoading = false;
@@ -603,9 +603,10 @@ class _HomeScreenState extends State<HomeScreen> {
       });
     } else {
       setState(() {
+        // print("result"+ result);
         isLoading = false;
         Fluttertoast.showToast(
-            msg: "Failed",
+            msg: result["message"],
             toastLength: Toast.LENGTH_SHORT,
             gravity: ToastGravity.BOTTOM);
       });


### PR DESCRIPTION
Documents that had contracts dependent on them were being deleted, which caused login issues for some users. When a user logged in, the app attempted to fetch contracts linked to the deleted documents, resulting in errors.

Changes made:
- Disabled deletion of documents that are linked to contracts.
- Updated the app’s error message for better clarity.